### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # base16-tridactyl
 Base16 Themes for the firefox [tridactyl](https://github.com/tridactyl/tridactyl) plugin
 
-clone this repo and copy themes into your tridactyl themes folder. Use `:help colourscheme` and `:help source` to figure out where to put your themes folder - see the tridactyl FAQ for more info.
+Two options for installation:
 
-Be sure to reload the page for the theme to take effect.
+- In Tridactyl, run `:colourscheme --url [URL to raw CSS of theme of your choice] [theme name of your choice]` e.g. `:colourscheme --url https://raw.githubusercontent.com/bezmi/base16-tridactyl/master/base16-bespin.css bespin`
+
+- __Or__ clone this repo and copy themes into your tridactyl themes folder. Use `:help colourscheme` and `:help source` to figure out where to put your themes folder - see the tridactyl FAQ for more info.
 
 The current themes are all based on the shydactyl theme. If you want the default theme with base16 colours, I will get around to it eventually. Feel free to post a pull request.


### PR DESCRIPTION
These work in the current Tridactyl betas and Tridactyl stable (unreleased) 1.21.0

You might want to wait for Tridactyl 1.21.0 to be released (perhaps within the next couple of weeks) before merging it, or you might not.

I knew if I didn't make this PR now I would forget to tell you : )