### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Base16 Themes for the firefox [tridactyl](https://github.com/tridactyl/tridactyl
 
 Two options for installation:
 
-- In Tridactyl, run `:colourscheme --url [URL to raw CSS of theme of your choice] [theme name of your choice]` e.g. `:colourscheme --url https://raw.githubusercontent.com/bezmi/base16-tridactyl/master/base16-bespin.css bespin`
+- In Tridactyl, run `:colorscheme --url [URL to raw CSS of theme of your choice] [theme name of your choice]` e.g. `:colorscheme --url https://raw.githubusercontent.com/bezmi/base16-tridactyl/master/base16-bespin.css bespin`
 
-- __Or__ clone this repo and copy themes into your tridactyl themes folder. Use `:help colourscheme` and `:help source` to figure out where to put your themes folder - see the tridactyl FAQ for more info.
+- __Or__ clone this repo and copy themes into your tridactyl themes folder. Use `:help colorscheme` and `:help source` to figure out where to put your themes folder - see the tridactyl FAQ for more info.
 
 The current themes are all based on the shydactyl theme. ~~If you want the default theme with base16 colours, I will get around to it eventually~~.
 


### PR DESCRIPTION
`colours` → `colors`

Maybe it used to work in an old version of tridactyl but it does not in the latest version.